### PR TITLE
nanovc-java-7: Searching for All Commits only returns Tags and Dangling Commits but ignores Branches.

### DIFF
--- a/memory/src/main/java/io/nanovc/memory/MemoryRepoEngineBase.java
+++ b/memory/src/main/java/io/nanovc/memory/MemoryRepoEngineBase.java
@@ -782,20 +782,23 @@ public abstract class MemoryRepoEngineBase<
 
         // Now we want to get all the commits for the repo.
 
+        // Create an initial set of commits to start traversing:
+        Set<TCommit> initialCommitSet = new LinkedHashSet<>();
+
+        // Get the commits for each branch:
+        initialCommitSet.addAll(repo.getBranchTips().values());
+
         // Get the commits for each tag:
-        commitSet.addAll(repo.getTags().values());
+        initialCommitSet.addAll(repo.getTags().values());
 
         // Get all the dangling commits that are not pointed to by a branch:
-        commitSet.addAll(repo.getDanglingCommits());
-
-        // Add the identities of all of the commits so far so that we don't process them again:
-        commitSet.forEach(tCommit -> identities.put(tCommit, tCommit));
+        initialCommitSet.addAll(repo.getDanglingCommits());
 
         // Walk the branches recursively and accumulate commits:
-        for (TCommit branchTipCommit : repo.getBranchTips().values())
+        for (TCommit tipCommit : initialCommitSet)
         {
-            // Extract the commits for this branch recursively:
-            extractCommitsRecursively(branchTipCommit, identities, commitSet);
+            // Extract the commits for this commit recursively:
+            extractCommitsRecursively(tipCommit, identities, commitSet);
         }
         // Now we have all of the commits for this repo.
 

--- a/memory/src/test/java/io/nanovc/memory/MemoryCommitSearchTests.java
+++ b/memory/src/test/java/io/nanovc/memory/MemoryCommitSearchTests.java
@@ -1,0 +1,62 @@
+package io.nanovc.memory;
+
+import io.nanovc.Commit;
+import io.nanovc.RepoPath;
+import io.nanovc.areas.ByteArrayHashMapArea;
+import io.nanovc.searches.commits.SimpleSearchQueryDefinition;
+import io.nanovc.searches.commits.expressions.AllRepoCommitsExpression;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the API for searching through {@link Commit}'s.
+ */
+public class MemoryCommitSearchTests extends MemoryNanoVersionControlTestsBase
+{
+    @Test
+    public void testSearchingForAllCommits()
+    {
+        // Create the repo:
+        MemoryNanoRepo nanoRepo = new MemoryNanoRepo();
+
+        // Create some content:
+        ByteArrayHashMapArea contentArea = nanoRepo.createArea();
+        contentArea.putBytes(RepoPath.atRoot(), new byte[0]);
+
+        // Commit the content to a branch several times to create some history:
+        MemoryCommit commit1 = nanoRepo.commitToBranch(contentArea, "master", "First Commit");
+        MemoryCommit commit2 = nanoRepo.commitToBranch(contentArea, "master", "Second Commit");
+        MemoryCommit commit3 = nanoRepo.commitToBranch(contentArea, "master", "Third Commit");
+
+        // Tag the second commit:
+        nanoRepo.tagCommit(commit2, "Interesting");
+
+        // Create a dangling commit:
+        nanoRepo.commit(contentArea, "Dingly-Dangly");
+
+        // Create the search query:
+        SimpleSearchQueryDefinition searchQueryDefinition = new SimpleSearchQueryDefinition(
+            null, AllRepoCommitsExpression.allRepoCommits(), null
+        );
+
+        // Run the search:
+        MemorySearchResults searchResults = nanoRepo.search(searchQueryDefinition);
+
+        // Get the commits from the search results:
+        List<MemoryCommit> allCommits = searchResults.getCommits();
+
+        // Map the results so we can assert them:
+        String allCommitStrings = allCommits.stream().map(commit -> commit.message).collect(Collectors.joining("\n"));
+
+        // Make sure the commits are as expected:
+        String expectedCommitStrings = "First Commit\n" +
+                                       "Second Commit\n" +
+                                       "Third Commit\n" +
+                                       "Dingly-Dangly";
+        assertEquals(expectedCommitStrings, allCommitStrings);
+    }
+}


### PR DESCRIPTION
Fixed the logic so that all commits are searched correctly.